### PR TITLE
Adding audio and track length helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.DS_Store
+__pycache__
+
 pysync-config.yml
 pysync.log
 resources

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pysync-config.yml
 pysync.log
+resources

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You need to set up your automation to load the correct file. Best results in Rad
 You'll need to go into Creek for your station and download the API key.
 
 1. Log in as a station admin, then:
-2. Tools > Settings > Integration > Scroll down to bottom > Secret Key
+2. Administration > Creek Settings > Integrations | Creek API > API Key
 
 Edit the `pysync-config.yml` configuration file to reflect this key.
 

--- a/audio.py
+++ b/audio.py
@@ -1,0 +1,22 @@
+from pydub import AudioSegment
+
+def generate_silence(output_path, minutes: int):
+    duration_ms = minutes * 60 * 1000 
+    silence = AudioSegment.silent(duration=duration_ms)
+    silence.export(output_path, format="mp3")
+
+def get_audio_duration_minutes_from_file(file_path):
+    audio = AudioSegment.from_file(file_path)
+    return get_audio_duration_minutes(audio)
+
+def get_audio_duration_minutes(audio: AudioSegment):
+    duration_ms = len(audio)
+    duration_minutes = duration_ms / (1000 * 60)
+    return duration_minutes
+
+def extend_mp3_with_other_file(base_path, additional_path):
+    audio = AudioSegment.from_file(base_path)
+    additional_audio = AudioSegment.from_file(additional_path)
+    return audio + additional_audio
+
+

--- a/audio.py
+++ b/audio.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydub import AudioSegment
 
 
@@ -22,3 +24,22 @@ def extend_mp3_with_other_file(base_path, additional_path):
     audio = AudioSegment.from_file(base_path)
     additional_audio = AudioSegment.from_file(additional_path)
     return audio + additional_audio
+
+
+def length_is_close_to_thirty_minute_boundary(
+    track_length_in_min: int, close_mins: int = 2
+):
+    """Looks at a track length and checks whether, when you round it to the closest 30 minutes,
+    the track is within plus or minus `close_mins` to that length.
+
+    We do this so that we can check whether 60, 90, or 120 minute shows are close to exactly their boundary.
+    """
+
+    moduloed_track_length = track_length_in_min % 30
+
+    if moduloed_track_length <= close_mins or moduloed_track_length >= (
+        30 - close_mins
+    ):
+        return True
+
+    return False

--- a/audio.py
+++ b/audio.py
@@ -1,22 +1,24 @@
 from pydub import AudioSegment
 
+
 def generate_silence(output_path, minutes: int):
-    duration_ms = minutes * 60 * 1000 
+    duration_ms = minutes * 60 * 1000
     silence = AudioSegment.silent(duration=duration_ms)
     silence.export(output_path, format="mp3")
+
 
 def get_audio_duration_minutes_from_file(file_path):
     audio = AudioSegment.from_file(file_path)
     return get_audio_duration_minutes(audio)
+
 
 def get_audio_duration_minutes(audio: AudioSegment):
     duration_ms = len(audio)
     duration_minutes = duration_ms / (1000 * 60)
     return duration_minutes
 
+
 def extend_mp3_with_other_file(base_path, additional_path):
     audio = AudioSegment.from_file(base_path)
     additional_audio = AudioSegment.from_file(additional_path)
     return audio + additional_audio
-
-

--- a/pysync.py
+++ b/pysync.py
@@ -34,6 +34,8 @@ from mutagen.id3 import ID3, TIT2, TALB, TPE1
 
 from slack_sdk.webhook import WebhookClient
 
+import audio
+
 # TODO: configuration file
 # TODO: email on directory creation (new show - won't play)
 # TODO: daemonize
@@ -258,6 +260,7 @@ def possibly_download_broadcast(broadcast):
         # TODO -- Add logic here to pad file if it's a length that would cause problems
 
         set_mp3_tag(local_filename, artist, album, title)
+        inspect_track_length(local_filename)
 
     else:
         LOGGER.info("download completed, but local file not available: {}".format(local_filename))
@@ -292,6 +295,14 @@ def set_mp3_tag(local_filename, artist, album, title):
         v1=ID3v1SaveOptions.CREATE,
         v2_version=4
     )
+
+def inspect_track_length(local_filename):
+    track_length = audio.get_audio_duration_minutes_from_file(local_filename)
+    LOGGER.info(f"Track is {track_length} minutes long")
+    if audio.length_is_close_to_thirty_minute_boundary(track_length):
+        LOGGER.info(f"Track is close to the 30 minute boundary zone!")
+
+
 
 # main function
 def fetch_upcoming():

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ pydub==0.25.1
 PyYAML==6.0.2
 slack_sdk==3.36.0
 tzlocal==5.3.1
-# Pytest
+# Pytest and tools
+black==25.1.0
 iniconfig==2.1.0
 packaging==25.0
 pluggy==1.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,12 @@
 APScheduler==3.11.0
 mutagen==1.47.0
+pydub==0.25.1
 PyYAML==6.0.2
 slack_sdk==3.36.0
 tzlocal==5.3.1
+# Pytest
+iniconfig==2.1.0
+packaging==25.0
+pluggy==1.6.0
+Pygments==2.19.2
+pytest==8.4.1

--- a/test_audio.py
+++ b/test_audio.py
@@ -1,10 +1,17 @@
+import os
 import tempfile
+
+from pydub.generators import Sine
 
 import audio
 
 
+INSPECTABLE_OUPUT_FILENAME = "listen_to_me.mp3"
+INSPECTABLE_PATH = os.path.join("resources", INSPECTABLE_OUPUT_FILENAME)
+
 
 def test_get_audio_duration():
+    """Test our helper can tell us audio duration"""
 
     with tempfile.NamedTemporaryFile(suffix=".mp3", delete=True) as temp:
         audio.generate_silence(temp.name, 10)
@@ -13,6 +20,7 @@ def test_get_audio_duration():
 
 
 def test_extend_file():
+    """Test we can add two files together and get an expected length"""
 
     with tempfile.NamedTemporaryFile(suffix=".mp3", delete=True) as temp1:
         with tempfile.NamedTemporaryFile(suffix=".mp3", delete=True) as temp2:
@@ -24,3 +32,27 @@ def test_extend_file():
             length_of_track = audio.get_audio_duration_minutes(combined_tracks)
             assert length_of_track == 13.0
 
+
+def test_extend_file_with_inspectable_output():
+    """Test we can add two files together in a way that leaves a file that a human can inspect to confirm
+    the second file is actually added to the end of the first one =)"""
+
+    tone1_freq = 440
+    tone2_freq = 550
+
+    with tempfile.NamedTemporaryFile(suffix=".mp3", delete=True) as temp1:
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=True) as temp2:
+            tone1 = Sine(tone1_freq).to_audio_segment(duration=2 * 1000 * 60)
+            tone1.export(temp1.name, format="mp3")
+
+            tone2 = Sine(tone2_freq).to_audio_segment(duration=1 * 1000 * 60)
+            tone2.export(temp2.name, format="mp3")
+
+            combined_tracks = audio.extend_mp3_with_other_file(temp1.name, temp2.name)
+
+            length_of_track = audio.get_audio_duration_minutes(combined_tracks)
+            assert length_of_track == 3
+
+            # A human should be able to listen to this track and see the higher tone
+            # lasts three minutes
+            combined_tracks.export(INSPECTABLE_PATH, format="mp3")

--- a/test_audio.py
+++ b/test_audio.py
@@ -56,3 +56,26 @@ def test_extend_file_with_inspectable_output():
             # A human should be able to listen to this track and see the higher tone
             # lasts three minutes
             combined_tracks.export(INSPECTABLE_PATH, format="mp3")
+
+
+def test_boundary_helper():
+
+    assert audio.length_is_close_to_thirty_minute_boundary(27, close_mins=2) is False
+    assert audio.length_is_close_to_thirty_minute_boundary(28, close_mins=2) is True
+    assert audio.length_is_close_to_thirty_minute_boundary(29, close_mins=2) is True
+    assert audio.length_is_close_to_thirty_minute_boundary(30) is True
+    assert audio.length_is_close_to_thirty_minute_boundary(31, close_mins=2) is True
+    assert audio.length_is_close_to_thirty_minute_boundary(32, close_mins=2) is True
+    assert audio.length_is_close_to_thirty_minute_boundary(33, close_mins=2) is False
+
+    assert audio.length_is_close_to_thirty_minute_boundary(57, close_mins=2) is False
+    assert audio.length_is_close_to_thirty_minute_boundary(59, close_mins=2) is True
+    assert audio.length_is_close_to_thirty_minute_boundary(60) is True
+    assert audio.length_is_close_to_thirty_minute_boundary(61, close_mins=2) is True
+    assert audio.length_is_close_to_thirty_minute_boundary(63, close_mins=2) is False
+
+    assert audio.length_is_close_to_thirty_minute_boundary(117, close_mins=2) is False
+    assert audio.length_is_close_to_thirty_minute_boundary(119, close_mins=2) is True
+    assert audio.length_is_close_to_thirty_minute_boundary(120) is True
+    assert audio.length_is_close_to_thirty_minute_boundary(122, close_mins=2) is True
+    assert audio.length_is_close_to_thirty_minute_boundary(123, close_mins=2) is False

--- a/test_audio.py
+++ b/test_audio.py
@@ -1,0 +1,26 @@
+import tempfile
+
+import audio
+
+
+
+def test_get_audio_duration():
+
+    with tempfile.NamedTemporaryFile(suffix=".mp3", delete=True) as temp:
+        audio.generate_silence(temp.name, 10)
+        length_of_track = audio.get_audio_duration_minutes_from_file(temp.name)
+        assert length_of_track == 10.0
+
+
+def test_extend_file():
+
+    with tempfile.NamedTemporaryFile(suffix=".mp3", delete=True) as temp1:
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=True) as temp2:
+            audio.generate_silence(temp1.name, 10)
+            audio.generate_silence(temp2.name, 3)
+
+            combined_tracks = audio.extend_mp3_with_other_file(temp1.name, temp2.name)
+
+            length_of_track = audio.get_audio_duration_minutes(combined_tracks)
+            assert length_of_track == 13.0
+

--- a/test_audio.py
+++ b/test_audio.py
@@ -60,13 +60,13 @@ def test_extend_file_with_inspectable_output():
 
 def test_boundary_helper():
 
-    assert audio.length_is_close_to_thirty_minute_boundary(27, close_mins=2) is False
-    assert audio.length_is_close_to_thirty_minute_boundary(28, close_mins=2) is True
-    assert audio.length_is_close_to_thirty_minute_boundary(29, close_mins=2) is True
-    assert audio.length_is_close_to_thirty_minute_boundary(30) is True
-    assert audio.length_is_close_to_thirty_minute_boundary(31, close_mins=2) is True
-    assert audio.length_is_close_to_thirty_minute_boundary(32, close_mins=2) is True
-    assert audio.length_is_close_to_thirty_minute_boundary(33, close_mins=2) is False
+    assert audio.length_is_close_to_thirty_minute_boundary(27.5, close_mins=2) is False
+    assert audio.length_is_close_to_thirty_minute_boundary(28.0, close_mins=2) is True
+    assert audio.length_is_close_to_thirty_minute_boundary(29.0, close_mins=2) is True
+    assert audio.length_is_close_to_thirty_minute_boundary(30.0) is True
+    assert audio.length_is_close_to_thirty_minute_boundary(31.0, close_mins=2) is True
+    assert audio.length_is_close_to_thirty_minute_boundary(32.0, close_mins=2) is True
+    assert audio.length_is_close_to_thirty_minute_boundary(32.1, close_mins=2) is False
 
     assert audio.length_is_close_to_thirty_minute_boundary(57, close_mins=2) is False
     assert audio.length_is_close_to_thirty_minute_boundary(59, close_mins=2) is True


### PR DESCRIPTION
Moving incrementally along towards our goal of extending tracks that are close to the end-of-the-show boundary length.

* Updates Readme based on where API keys are currently found in Creek
* Adds libraries and functionality to:
    - Check a track length in minutes
    - Check if a track length is closed to the 30 minute boundary
    - Combine two mp3s together
  * Adds pytest and test of new library functionality

Once this is merged we'll still want to figure out what we want to extend files with, where the filler file will be located on the automation machine, and implement that logic (and see if we need to do anything with mp3 tags after that's done).